### PR TITLE
docs: deprecation notice (superseded by ovos-gguf-plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # GGUF Solver
 
+> **Deprecated.** This plugin is superseded by **[`ovos-gguf-plugin`](https://github.com/TigreGotico/ovos-gguf-plugin)**,
+> which bundles every GGUF wrapper (chat, summarizer, dialog transformer, translate, lang detect, embeddings) in one
+> package. Its `opm.agents.chat` engine (`GGUFChatEngine`) replaces this `QuestionSolver`. Install `ovos-gguf-plugin`
+> instead.
+
 ## Overview
 
 `GGUFSolver` is a question-answering module that utilizes GGUF models to provide responses to user queries. This solver


### PR DESCRIPTION
The legacy QuestionSolver is superseded by the unified `ovos-gguf-plugin`'s `opm.agents.chat` engine. Adds a README deprecation banner. Repo to be archived after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)