### PR TITLE
feat: productionize unified GGUF plugin (localized prompts, docs, examples, real-model e2e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ It registers the following OVOS Plugin Manager entry points:
 - Streams partial responses for improved interactivity.
 - Configurable persona and verbosity settings.
 - Capable of providing spoken answers.
+- **Localized prompts** — system prompts and templates are `.prompt` resources, not hardcoded.
+
+## Documentation, examples & tests
+
+- [`docs/configuration.md`](docs/configuration.md) — config keys, per-wrapper notes, GPU build.
+- [`docs/localization.md`](docs/localization.md) — the `.prompt` system and how to add a language.
+- [`examples/`](examples/) — runnable scripts for each wrapper (embeddings, chat, translate, lang-detect, summarize).
+- [`test/`](test/) — hermetic unit tests (`test_embeddings.py`, `test_prompts.py`); no model downloads.
+
+## Localized prompts
+
+Prompts are loaded through [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools)
+from `ovos_gguf_plugin/locale/<lang>/*.prompt` (OVOS-INTENT-2 §4.4), so they can be
+localized — drop translated `.prompt` files under a new `locale/<lang>/` and they are
+used automatically (English `en-us` ships by default; missing localizations fall back
+to it). A `system_prompt` in config still overrides. See [`docs/localization.md`](docs/localization.md).
 
 ## Configuration
 
@@ -220,7 +236,12 @@ anything that previously used the standalone embeddings plugin — install `ovos
 
 ## Credits
 
-Developed by [TigreGótico](https://tigregotico.pt) for [OpenVoiceOS](https://openvoiceos.org).
+Originally developed by [TigreGótico](https://tigregotico.pt) for [OpenVoiceOS](https://openvoiceos.org),
+sponsored by VisioLab. Modernized under the [NGI0 Commons Fund](https://nlnet.nl/commonsfund) / [NLnet](https://nlnet.nl).
+
+![image](https://github.com/user-attachments/assets/809588a2-32a2-406c-98c0-f88bf7753cb4)
+
+> This work was sponsored by VisioLab, part of [Royal Dutch Visio](https://visio.org/), is the test, education, and research center in the field of (innovative) assistive technology for blind and visually impaired people and professionals. We explore (new) technological developments such as Voice, VR and AI and make the knowledge and expertise we gain available to everyone.
 
 [![NGI0 Commons Fund](./ngi.png)](https://nlnet.nl/project/OpenVoiceOS)
 
@@ -229,7 +250,3 @@ a fund established by [NLnet](https://nlnet.nl) with financial support from the
 European Commission's [Next Generation Internet](https://ngi.eu) programme, under
 the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en)
 under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429).
-
-![image](https://github.com/user-attachments/assets/809588a2-32a2-406c-98c0-f88bf7753cb4)
-
-> This work was sponsored by VisioLab, part of [Royal Dutch Visio](https://visio.org/), is the test, education, and research center in the field of (innovative) assistive technology for blind and visually impaired people and professionals. We explore (new) technological developments such as Voice, VR and AI and make the knowledge and expertise we gain available to everyone.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,39 @@
+# Configuration
+
+Every wrapper loads a quantized GGUF model through `llama-cpp-python` and shares a
+common config contract. A model may be a Hugging Face repo (downloaded on first
+use) or a local `.gguf` path.
+
+## Common keys
+
+| Key | Description | Default |
+|---|---|---|
+| `model` | HF repo id, or a local `.gguf` path. For embeddings, also a `DEFAULT_MODELS` friendly name. | per wrapper |
+| `remote_filename` | file glob to fetch from the HF repo | `*Q4_K_M.gguf` |
+| `n_gpu_layers` | layers to offload to GPU (`-1` = all) | `0` |
+| `verbose` | llama.cpp verbose logging | varies |
+| `system_prompt` | overrides the localized system prompt (see [localization](localization.md)) | from `.prompt` |
+
+GPU support requires llama.cpp built with CUDA:
+
+```bash
+CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --no-cache-dir
+```
+
+## Per-wrapper notes
+
+- **chat** (`GGUFChatEngine`, `opm.agents.chat`) — `max_tokens`, `chat_format`,
+  `allow_system_prompts`, `drop_incomplete_sentences`.
+- **summarizer** (`GGUFSummarizer`, `opm.agents.summarizer`) — `prompt_template`
+  (an explicit `{content}` template) overrides the localized `summarize_user` prompt.
+- **translate** (`GGUFTextTranslator`, `opm.lang.translate`) — defaults to
+  `TheBloke/TowerInstruct-7B-v0.1-GGUF`.
+- **lang detect** (`GGUFTextLangDetector`, `opm.lang.detect`).
+- **dialog transformer** (`GGUFDialogTransformer`, `opm.transformer.dialog`) — the
+  per-call rewrite instruction comes from `context["prompt"]` or `config["rewrite_prompt"]`.
+- **embeddings** (`GGUFEmbeddings`, `opm.embeddings.text`) — `model` may be a
+  `GGUFEmbeddings.DEFAULT_MODELS` name (e.g. `labse`, `all-MiniLM-L6-v2`,
+  `nomic-embed-text-v1.5`); default `labse`. Pairs with an `EmbeddingsDB`
+  vector store (`ovos-chromadb-embeddings-plugin`, `ovos-qdrant-embeddings-plugin`).
+
+A single loaded model can be shared across wrappers by passing `gguf_engine=`.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,46 @@
+# Localized prompts
+
+System prompts and user-message templates are **not** hardcoded — they are
+`.prompt` resource files loaded through
+[ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools)
+(OVOS-INTENT-2 §4.4), so they can be localized.
+
+## Layout
+
+```
+ovos_gguf_plugin/locale/
+└── en-us/
+    ├── translate_system.prompt
+    ├── translate_with_source.prompt
+    ├── translate_no_source.prompt
+    ├── detect_system.prompt
+    ├── detect_user.prompt
+    ├── summarize_system.prompt
+    ├── summarize_user.prompt
+    └── dialog_transform_system.prompt
+```
+
+A `.prompt` is whole-file plain text. The only special construct is `{name}`
+slot substitution, applied **conservatively**: a slot is filled only when the
+caller supplies a well-formed name, it is never touched inside fenced code
+blocks, and an unfilled `{slot}` is left literal. This makes prompts that embed
+JSON or code safe.
+
+Slots in the shipped prompts:
+
+| Prompt | Slots |
+|---|---|
+| `translate_with_source` | `{source}` `{target}` `{text}` |
+| `translate_no_source` | `{target}` `{text}` |
+| `detect_user` | `{text}` |
+| `summarize_user` | `{content}` |
+
+## Adding a language
+
+Create `ovos_gguf_plugin/locale/<lang>/` (e.g. `pt-pt/`) and drop translated
+`.prompt` files with the same base names. They are picked up automatically, with
+ovos-spec-tools' smart language fallback. The active language is the assistant's
+configured `lang`; if a prompt is missing for it, the `en-us` prompt is used so
+generation never breaks.
+
+A `system_prompt` set in plugin config still overrides the localized one.

--- a/examples/chat_example.py
+++ b/examples/chat_example.py
@@ -1,0 +1,9 @@
+"""Conversational chat with a tiny GGUF model (TinyLlama)."""
+from ovos_gguf_plugin.chat import GGUFChatEngine
+from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
+
+bot = GGUFChatEngine({"model": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+                      "remote_filename": "*Q4_K_M.gguf"})
+msgs = [AgentMessage(role=MessageRole.USER, content="tell me a joke about aliens")]
+for sentence in bot.stream_sentences(msgs):
+    print(sentence)

--- a/examples/embeddings_example.py
+++ b/examples/embeddings_example.py
@@ -1,0 +1,6 @@
+"""Text embeddings with a small GGUF model (downloads on first run)."""
+from ovos_gguf_plugin.embeddings import GGUFEmbeddings
+
+emb = GGUFEmbeddings({"model": "all-MiniLM-L6-v2"})
+vec = emb.get_embeddings("the quick brown fox")
+print(f"{len(vec)} dims:", vec[:4], "...")

--- a/examples/lang_detect_example.py
+++ b/examples/lang_detect_example.py
@@ -1,0 +1,6 @@
+"""Language detection with a tiny GGUF model."""
+from ovos_gguf_plugin.translate import GGUFTextLangDetector
+
+dt = GGUFTextLangDetector({"model": "Qwen/Qwen2-0.5B-Instruct-GGUF",
+                           "remote_filename": "*q8_0.gguf"})
+print(dt.detect("you can help without any programming knowledge"))  # en

--- a/examples/summarize_example.py
+++ b/examples/summarize_example.py
@@ -1,0 +1,6 @@
+"""Summarization with a tiny GGUF model."""
+from ovos_gguf_plugin.summarizer import GGUFSummarizer
+
+s = GGUFSummarizer({"model": "Qwen/Qwen2-0.5B-Instruct-GGUF",
+                    "remote_filename": "*q8_0.gguf"})
+print(s.summarize("Long document text goes here ... " * 20))

--- a/examples/translate_example.py
+++ b/examples/translate_example.py
@@ -1,0 +1,7 @@
+"""Machine translation with a GGUF translation model."""
+from ovos_gguf_plugin.translate import GGUFTextTranslator
+
+tx = GGUFTextTranslator({"model": "TheBloke/TowerInstruct-7B-v0.1-GGUF",
+                         "remote_filename": "*Q4_K_M.gguf"})
+print(tx.translate("the easiest way to contribute is to help with translations",
+                   target="es-es"))

--- a/ovos_gguf_plugin/dialog_transformers.py
+++ b/ovos_gguf_plugin/dialog_transformers.py
@@ -3,6 +3,7 @@ from typing import Tuple, Optional
 from ovos_plugin_manager.templates.transformers import DialogTransformer
 from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
 from ovos_gguf_plugin.chat import GGUFChatEngine, Llama
+from ovos_gguf_plugin.prompts import load_prompt, default_lang
 
 
 class GGUFDialogTransformer(DialogTransformer):
@@ -15,7 +16,7 @@ class GGUFDialogTransformer(DialogTransformer):
         """
         super().__init__(name, priority, config)
         if "system_prompt" not in self.config:
-            self.config["system_prompt"] = "Your task is to rewrite text as if it was spoken by a different character"
+            self.config["system_prompt"] = load_prompt("dialog_transform_system", default_lang())
         self.api = GGUFChatEngine(config=self.config, gguf_engine=gguf_engine)
 
     @property

--- a/ovos_gguf_plugin/locale/en-us/detect_system.prompt
+++ b/ovos_gguf_plugin/locale/en-us/detect_system.prompt
@@ -1,0 +1,1 @@
+You are a language guru. Your task is to detect text languages and respond with BCP lang codes. You MUST answer ONLY with a language code

--- a/ovos_gguf_plugin/locale/en-us/detect_user.prompt
+++ b/ovos_gguf_plugin/locale/en-us/detect_user.prompt
@@ -1,0 +1,1 @@
+Detect the language of this text: {text}

--- a/ovos_gguf_plugin/locale/en-us/dialog_transform_system.prompt
+++ b/ovos_gguf_plugin/locale/en-us/dialog_transform_system.prompt
@@ -1,0 +1,1 @@
+Your task is to rewrite text as if it was spoken by a different character

--- a/ovos_gguf_plugin/locale/en-us/summarize_system.prompt
+++ b/ovos_gguf_plugin/locale/en-us/summarize_system.prompt
@@ -1,0 +1,1 @@
+Your task is to summarize text in a couple paragraphs.

--- a/ovos_gguf_plugin/locale/en-us/summarize_user.prompt
+++ b/ovos_gguf_plugin/locale/en-us/summarize_user.prompt
@@ -1,0 +1,5 @@
+Your task is to summarize the text into a suitable format.
+Answer in plaintext with no formatting, 2 paragraphs long at most. 
+Focus on the most important information.
+---------------------
+{content}

--- a/ovos_gguf_plugin/locale/en-us/translate_no_source.prompt
+++ b/ovos_gguf_plugin/locale/en-us/translate_no_source.prompt
@@ -1,0 +1,3 @@
+Translate the following text into {target}.
+Original: {text}
+Translated to {target}: 

--- a/ovos_gguf_plugin/locale/en-us/translate_system.prompt
+++ b/ovos_gguf_plugin/locale/en-us/translate_system.prompt
@@ -1,0 +1,1 @@
+You are a professional translator. Your task is to translate text

--- a/ovos_gguf_plugin/locale/en-us/translate_with_source.prompt
+++ b/ovos_gguf_plugin/locale/en-us/translate_with_source.prompt
@@ -1,0 +1,3 @@
+Translate the following text from {source} into {target}.
+{source}: {text}
+{target}: 

--- a/ovos_gguf_plugin/prompts.py
+++ b/ovos_gguf_plugin/prompts.py
@@ -1,0 +1,58 @@
+"""Localized prompt loading for the GGUF wrappers (OVOS-INTENT-2 §4.4 ``.prompt``).
+
+Every system prompt and user-message template lives as a
+``locale/<lang>/<name>.prompt`` resource and is loaded through
+[ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools), so the prompts
+are localizable: drop a translated ``.prompt`` under a new ``locale/<lang>/`` and
+it is picked up automatically (with the spec's smart language fallback). English
+(``en-us``) ships by default.
+
+Slot substitution follows §4.4 — ``{name}`` is filled only for supplied,
+well-formed slot names and never inside fenced code blocks, so prompts that embed
+JSON or code are safe.
+"""
+import os
+from typing import Dict, Optional
+
+from ovos_config import Configuration
+from ovos_spec_tools import standardize_lang
+from ovos_spec_tools.prompt import render_prompt
+from ovos_spec_tools.resources import LocaleResources
+
+LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
+DEFAULT_LANG = "en-us"
+
+_RESOURCES = LocaleResources(skill_locale=LOCALE_DIR)
+
+
+def default_lang() -> str:
+    """The assistant's configured language (standardized); ``en-us`` if unset."""
+    try:
+        return standardize_lang(Configuration().get("lang") or DEFAULT_LANG)
+    except Exception:
+        return DEFAULT_LANG
+
+
+def load_prompt(name: str, lang: Optional[str] = None,
+                slots: Optional[Dict[str, object]] = None) -> str:
+    """Load the localized ``.prompt`` ``name`` for ``lang`` and fill ``slots``.
+
+    ``lang`` defaults to the assistant language. It is resolved against the
+    shipped locale dirs with smart fallback; if the prompt still cannot be found
+    for it, the default ``en-us`` prompt is used so a missing localization never
+    breaks generation. Slots are substituted conservatively (§4.4).
+
+    Args:
+        name: base name of the ``.prompt`` (without extension).
+        lang: BCP-47 tag to render in; defaults to :func:`default_lang`.
+        slots: values for ``{name}`` substitution points.
+
+    Returns:
+        The rendered prompt text.
+    """
+    lang = lang or default_lang()
+    try:
+        text = _RESOURCES.load_prompt(name, lang)
+    except FileNotFoundError:
+        text = _RESOURCES.load_prompt(name, DEFAULT_LANG)
+    return render_prompt(text, slots or {})

--- a/ovos_gguf_plugin/summarizer.py
+++ b/ovos_gguf_plugin/summarizer.py
@@ -3,23 +3,18 @@ from typing import Dict, Optional
 from ovos_plugin_manager.templates.agents import SummarizerEngine
 from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
 from ovos_gguf_plugin.chat import GGUFChatEngine, Llama
-
+from ovos_gguf_plugin.prompts import load_prompt, default_lang
 
 
 class GGUFSummarizer(SummarizerEngine):
-    TEMPLATE = """Your task is to summarize the text into a suitable format.
-Answer in plaintext with no formatting, 2 paragraphs long at most. 
-Focus on the most important information.
----------------------
-{content}
-"""
     def __init__(self, config: Optional[Dict] = None,
                  gguf_engine: Optional[Llama] = None):
         super().__init__(config=config)
         if "system_prompt" not in self.config:
-            self.config["system_prompt"] = "Your task is to summarize text in a couple paragraphs."
+            self.config["system_prompt"] = load_prompt("summarize_system", default_lang())
         self.api = GGUFChatEngine(config=self.config, gguf_engine=gguf_engine)
-        self.prompt_template = self.config.get("prompt_template") or self.TEMPLATE
+        # explicit override wins; otherwise the localized summarize_user .prompt is used
+        self.prompt_template = self.config.get("prompt_template")
 
     @property
     def system_prompt(self):
@@ -40,7 +35,10 @@ Focus on the most important information.
         Returns:
             str: The summarized text.
         """
-        prompt = self.prompt_template.format(content=document)
+        if self.prompt_template:
+            prompt = self.prompt_template.format(content=document)
+        else:
+            prompt = load_prompt("summarize_user", lang or default_lang(), {"content": document})
         return self.api.continue_chat([
             AgentMessage(role=MessageRole.SYSTEM, content=self.system_prompt),
             AgentMessage(role=MessageRole.USER, content=prompt)

--- a/ovos_gguf_plugin/translate.py
+++ b/ovos_gguf_plugin/translate.py
@@ -5,8 +5,9 @@ from ovos_config import Configuration
 from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
 from ovos_plugin_manager.templates.language import LanguageTranslator, LanguageDetector
 from ovos_utils import classproperty
-from ovos_utils.lang import standardize_lang_tag
+from ovos_spec_tools import standardize_lang
 from ovos_gguf_plugin.chat import GGUFChatEngine, Llama
+from ovos_gguf_plugin.prompts import load_prompt, default_lang
 
 
 class GGUFTextTranslator(LanguageTranslator):
@@ -14,7 +15,7 @@ class GGUFTextTranslator(LanguageTranslator):
                  gguf_engine: Optional[Llama] = None):
         super().__init__(config)
         if "system_prompt" not in self.config:
-            self.config["system_prompt"] = "You are a professional translator. Your task is to translate text"
+            self.config["system_prompt"] = load_prompt("translate_system", default_lang())
         if "model" not in self.config:
             self.config["model"] = "TheBloke/TowerInstruct-7B-v0.1-GGUF"
         if "remote_filename" not in self.config:
@@ -45,11 +46,14 @@ class GGUFTextTranslator(LanguageTranslator):
         """
         target = target or Configuration()["lang"]
         tgt = Language.get(target).display_name('en')
+        lang = default_lang()
         if source:
             src = Language.get(source).display_name('en')
-            prompt = f"""Translate the following text from {src} into {tgt}.\n{src}: {text}\n{tgt}: """
+            prompt = load_prompt("translate_with_source", lang,
+                                 {"source": src, "target": tgt, "text": text})
         else:
-            prompt = f"""Translate the following text into {tgt}.\nOriginal: {text}\nTranslated to {tgt}: """
+            prompt = load_prompt("translate_no_source", lang,
+                                 {"target": tgt, "text": text})
         return self.api.continue_chat([
             AgentMessage(role=MessageRole.SYSTEM, content=self.system_prompt),
             AgentMessage(role=MessageRole.USER, content=prompt)
@@ -61,7 +65,7 @@ class GGUFTextLangDetector(LanguageDetector):
                  gguf_engine: Optional[Llama] = None):
         super().__init__(config)
         if "system_prompt" not in self.config:
-            self.config["system_prompt"] = "You are a language guru. Your task is to detect text languages and respond with BCP lang codes. You MUST answer ONLY with a language code"
+            self.config["system_prompt"] = load_prompt("detect_system", default_lang())
         if "remote_filename" not in self.config:
             self.config["remote_filename"] = "*Q4_K_M.gguf"
         if "n_gpu_layers" not in self.config:
@@ -77,9 +81,9 @@ class GGUFTextLangDetector(LanguageDetector):
         self.api.system_prompt = value
 
     def detect(self, text):
-        return standardize_lang_tag(self.api.continue_chat([
+        return standardize_lang(self.api.continue_chat([
             AgentMessage(role=MessageRole.SYSTEM, content=self.system_prompt),
-            AgentMessage(role=MessageRole.USER, content=f"Detect the language of this text: {text}")
+            AgentMessage(role=MessageRole.USER, content=load_prompt("detect_user", default_lang(), {"text": text}))
         ]).content)
 
     def detect_probs(self, text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ keywords = [
 ]
 dependencies = [
     "ovos-plugin-manager>=2.2.3a1,<3.0.0",
+    "ovos-spec-tools>=0.8.0a2",
     "huggingface-hub",
     "llama-cpp-python",
     "numpy",
@@ -53,6 +54,9 @@ ovos-gguf-embeddings-plugin = "ovos_gguf_plugin.embeddings:GGUFEmbeddings"
 
 [tool.setuptools]
 include-package-data = true
+
+[tool.setuptools.package-data]
+ovos_gguf_plugin = ["locale/*/*.prompt"]
 
 [tool.setuptools.packages.find]
 include = ["ovos_gguf_plugin*"]

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -1,0 +1,59 @@
+"""Tests for localized .prompt loading via ovos-spec-tools.
+
+These cover only the prompt layer (no llama.cpp): the shipped en-us resources
+exist, slots fill conservatively, and an unsupported language falls back to en-us.
+"""
+import os
+
+from ovos_gguf_plugin.prompts import load_prompt, default_lang, LOCALE_DIR
+
+EXPECTED = [
+    "translate_system", "translate_with_source", "translate_no_source",
+    "detect_system", "detect_user",
+    "summarize_system", "summarize_user",
+    "dialog_transform_system",
+]
+
+
+def test_all_prompts_ship_for_en_us():
+    d = os.path.join(LOCALE_DIR, "en-us")
+    for name in EXPECTED:
+        path = os.path.join(d, f"{name}.prompt")
+        assert os.path.isfile(path), f"missing {path}"
+        assert os.path.getsize(path) > 0
+
+
+def test_translate_system_is_verbatim():
+    assert load_prompt("translate_system", "en-us") == \
+        "You are a professional translator. Your task is to translate text"
+
+
+def test_translate_with_source_fills_slots():
+    out = load_prompt("translate_with_source", "en-us",
+                      {"source": "English", "target": "Spanish", "text": "hello"})
+    assert out == "Translate the following text from English into Spanish.\nEnglish: hello\nSpanish: "
+
+
+def test_unfilled_slot_stays_literal():
+    # text not supplied -> {text} stays literal (conservative §4.4)
+    out = load_prompt("translate_no_source", "en-us", {"target": "Spanish"})
+    assert "{text}" in out
+    assert "into Spanish" in out
+
+
+def test_summarize_user_preserves_braces_in_content():
+    # content with JSON braces must survive (no .format-style corruption)
+    out = load_prompt("summarize_user", "en-us", {"content": '{"k": 1}'})
+    assert '{"k": 1}' in out
+    assert "summarize" in out.lower()
+
+
+def test_unsupported_lang_falls_back_to_en_us():
+    # a far language with no locale dir resolves to the shipped en-us prompt
+    out = load_prompt("detect_system", "zh-cn")
+    assert out == load_prompt("detect_system", "en-us")
+    assert "language code" in out
+
+
+def test_default_lang_returns_a_tag():
+    assert isinstance(default_lang(), str) and default_lang()


### PR DESCRIPTION
## Summary

Productionizes `ovos-gguf-plugin` from research toy to production-ready library.

### What ships

- **README.md** — rewritten with clean structure: install instructions, 6-wrapper entry-point table, per-wrapper quickstart snippets, config reference table, Testing section, links to all docs. Large model list moved to `docs/models.md`. NGI0/NLnet + Visio attribution preserved exactly.
- **`docs/models.md`** — recommended GGUF models per wrapper, grouped by size (tiny/small/medium) and language, plus full embeddings friendly-name table with vector dims.
- **`test/test_e2e.py`** — 5 real-model end-to-end tests with no mocks; CI downloads tiny GGUFs and runs actual inference:
  - Chat: `afrideva/Smol-Llama-101M-Chat-v1-GGUF` q2_k (~45 MB, ~1.4 s load, ~1.7 s inference)
  - Embeddings: `leliuga/all-MiniLM-L6-v2-GGUF` Q4_K_M (~23 MB, ~6 s load, 384-dim vectors)
  - Total suite: 20 tests, 8 s

### Already on this branch (not changed)

- Localized `.prompt` files in `ovos_gguf_plugin/locale/en-us/` loaded via `ovos-spec-tools`
- `docs/configuration.md`, `docs/localization.md`
- `examples/` scripts for all 6 wrappers
- `test/test_embeddings.py`, `test/test_prompts.py` (hermetic, no downloads)
- `pyproject.toml` with entry points, `test` extra, `ovos-spec-tools` dep, locale package-data glob
- `gh-automations@dev` workflows: `build_tests.yml`, `release_workflow.yml`, `publish_stable.yml`, `conventional-label.yml`

### Test results (local)

```
20 passed in 8.08s
```