### PR TITLE
feat: productionize unified GGUF plugin (new README, docs, real-model e2e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # ovos-gguf-plugin
 
-## Overview
+Unified GGUF wrapper for OpenVoiceOS — chat, summarization, dialog rewriting, translation, language detection, and text embeddings, all backed by quantized GGUF models via `llama-cpp-python`.
 
-A single plugin packaging every GGUF-backed wrapper for OpenVoiceOS. All wrappers run quantized GGUF models through
-`llama-cpp-python`, loading from a local `.gguf` file or straight from the Hugging Face Hub (`repo_id` + `remote_filename`).
+## Install
 
-It registers the following OVOS Plugin Manager entry points:
+```bash
+pip install ovos-gguf-plugin
+```
+
+For GPU inference, rebuild `llama-cpp-python` with CUDA support first:
+
+```bash
+CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --no-cache-dir
+```
+
+## Plugin entry points
 
 | Entry-point group | Plugin name | Class | Role |
 |---|---|---|---|
@@ -16,230 +25,169 @@ It registers the following OVOS Plugin Manager entry points:
 | `opm.lang.detect` | `ovos-lang-detect-gguf-plugin` | `GGUFTextLangDetector` | language detection |
 | `opm.embeddings.text` | `ovos-gguf-embeddings-plugin` | `GGUFEmbeddings` | text embeddings |
 
-## Features
+## Quickstart
 
-- Supports loading GGUF models from local files or remote repositories.
-- Streams partial responses for improved interactivity.
-- Configurable persona and verbosity settings.
-- Capable of providing spoken answers.
-- **Localized prompts** — system prompts and templates are `.prompt` resources, not hardcoded.
-
-## Documentation, examples & tests
-
-- [`docs/configuration.md`](docs/configuration.md) — config keys, per-wrapper notes, GPU build.
-- [`docs/localization.md`](docs/localization.md) — the `.prompt` system and how to add a language.
-- [`examples/`](examples/) — runnable scripts for each wrapper (embeddings, chat, translate, lang-detect, summarize).
-- [`test/`](test/) — hermetic unit tests (`test_embeddings.py`, `test_prompts.py`); no model downloads.
-
-## Localized prompts
-
-Prompts are loaded through [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools)
-from `ovos_gguf_plugin/locale/<lang>/*.prompt` (OVOS-INTENT-2 §4.4), so they can be
-localized — drop translated `.prompt` files under a new `locale/<lang>/` and they are
-used automatically (English `en-us` ships by default; missing localizations fall back
-to it). A `system_prompt` in config still overrides. See [`docs/localization.md`](docs/localization.md).
-
-## Configuration
-
-`GGUFSolver` requires a configuration dictionary. The configuration should at least specify the model to use. Here is an
-example configuration:
-
-```python
-cfg = {
-    "model": "TheBloke/notus-7B-v1-GGUF",
-    "remote_filename": "*Q4_K_M.gguf"
-}
-```
-
-- `model`: The identifier for the model. It can be a local file path or a repository ID for a remote model.
-- `n_gpu_layers`: how many layer to offload to GPU, `-1` to offload all. default `0`
-- `remote_filename`: The specific filename to load from a remote repository.
-- `chat_format`: (Optional) Chat formatting settings.
-- `verbose`: (Optional) Set to `True` for detailed logging.
-- `persona`: (Optional) Persona for the system messages. Default
-  is `"You are a helpful assistant who gives short factual answers"`.
-- `max_tokens`: (Optional) Maximum tokens for the response. Default is `512`.
-
-**NOTE**: for GPU support llama.cpp needs to be compiled with
-
-`CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --no-cache-dir`
-
-## Usage
-
-### Initializing the Solver
+### Chat
 
 ```python
 from ovos_gguf_plugin.chat import GGUFChatEngine
-from ovos_utils.log import LOG
+from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
 
-LOG.set_level("DEBUG")
-
-cfg = {
-    "model": "TheBloke/notus-7B-v1-GGUF",
-    "remote_filename": "*Q4_K_M.gguf"
-}
-
-solver = GGUFChatEngine(cfg)
-```
-
-### Streaming Utterances
-
-Use the `stream_utterances` method to stream responses. This is particularly useful for real-time applications such as
-voice assistants.
-
-```python
-query = "tell me a joke about aliens"
-for sentence in solver.stream_utterances(query):
+engine = GGUFChatEngine({
+    "model": "afrideva/Smol-Llama-101M-Chat-v1-GGUF",
+    "remote_filename": "*q2_k.gguf",
+    "max_tokens": 128,
+})
+msgs = [AgentMessage(role=MessageRole.USER, content="Tell me a joke.")]
+# stream sentence-by-sentence (suitable for TTS)
+for sentence in engine.stream_sentences(msgs):
     print(sentence)
+# or get the full response at once
+reply = engine.continue_chat(msgs)
+print(reply.content)
 ```
 
-### Getting a Full Answer
-
-Use the `get_spoken_answer` method to get a complete response.
+### Summarizer
 
 ```python
-query = "What is the capital of France?"
-answer = solver.get_spoken_answer(query)
-print(answer)
+from ovos_gguf_plugin.summarizer import GGUFSummarizer
+
+s = GGUFSummarizer({
+    "model": "Qwen/Qwen2-0.5B-Instruct-GGUF",
+    "remote_filename": "*q8_0.gguf",
+})
+print(s.summarize("Long document text goes here ... " * 20))
 ```
 
-## Integrating with Persona Framework
+### Dialog transformer
 
-To integrate `GGUFSolver` with the OVOS Persona Framework and pass solver configurations, follow these examples.
+```python
+from ovos_gguf_plugin.dialog_transformers import GGUFDialogTransformer
 
-Each example demonstrates how to define a persona configuration file with specific settings for different models or configurations.
-
-To use any of these configurations, run the OVOS Persona Server with the desired configuration file:
-
-```bash
-$ ovos-persona-server --persona gguf_persona_remote.json
+dt = GGUFDialogTransformer({
+    "model": "Qwen/Qwen2-0.5B-Instruct-GGUF",
+    "remote_filename": "*q8_0.gguf",
+})
+print(dt.transform("gonna grab some food real quick"))
 ```
 
-Replace `gguf_persona_remote.json` with the filename of the configuration you wish to use.
+### Translation
 
-### Example 1: Using a Remote GGUF Model
+```python
+from ovos_gguf_plugin.translate import GGUFTextTranslator
 
-This example shows how to configure the `GGUFSolver` to use a remote GGUF model with a specific persona.
-
-**`gguf_persona_remote.json`**:
-
-```json
-{
-  "name": "Notus",
-  "solvers": [
-    "ovos-solver-gguf-plugin"
-  ],
-  "ovos-solver-gguf-plugin": {
-    "model": "TheBloke/notus-7B-v1-GGUF",
+tx = GGUFTextTranslator({
+    "model": "TheBloke/TowerInstruct-7B-v0.1-GGUF",
     "remote_filename": "*Q4_K_M.gguf",
-    "persona": "You are an advanced assistant providing detailed and accurate information.",
-    "verbose": true
-  }
-}
+})
+print(tx.translate("the easiest way to contribute is to help with translations",
+                   target="es-es"))
 ```
 
-In this configuration:
-- `ovos-solver-gguf-plugin` is set to use a remote GGUF model `TheBloke/notus-7B-v1-GGUF` with the specified filename.
-- The persona is configured to provide detailed and accurate information.
-- `verbose` is set to `true` for detailed logging.
+### Language detection
 
-### Example 2: Using a Local GGUF Model
+```python
+from ovos_gguf_plugin.translate import GGUFTextLangDetector
 
-This example shows how to configure the `GGUFSolver` to use a local GGUF model.
-
-**`gguf_persona_local.json`**:
-
-```json
-{
-  "name": "LocalGGUFPersona",
-  "solvers": [
-    "ovos-solver-gguf-plugin"
-  ],
-  "ovos-solver-gguf-plugin": {
-    "model": "/path/to/local/model/gguf_model.gguf",
-    "persona": "You are a helpful assistant providing concise answers.",
-    "max_tokens": 256
-  }
-}
+dt = GGUFTextLangDetector({
+    "model": "Qwen/Qwen2-0.5B-Instruct-GGUF",
+    "remote_filename": "*q8_0.gguf",
+})
+print(dt.detect("you can help without any programming knowledge"))  # → en
 ```
 
-In this configuration:
-- `ovos-solver-gguf-plugin` is set to use a local GGUF model located at `/path/to/local/model/gguf_model.gguf`.
-- The persona is configured to provide concise answers.
-- `max_tokens` is set to `256` to limit the response length.
-
-
-### Example Models
-
-these models are not endorsed and this list was largely compiling by searching hugging face, only for illustrative
-purposes
-
-| Language   | Model Name                                          | URL                                                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                             |
-|------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| English    | CausalLM-14B-GGUF                                   | [Link](https://huggingface.co/TheBloke/CausalLM-14B-GGUF)                                        | A 14B parameter model compatible with Meta LLaMA 2, demonstrating top-tier performance among models with fewer than 70B parameters, optimized for both qualitative and quantitative evaluations, with strong consistency across versions.                                                                                                                                                               |
-| English    | Phi-3-Mini-4K-Instruct-GGUF                         | [Link](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf)                             | A lightweight 3.8B parameter model from the Phi-3 family, optimized for strong reasoning and long-context tasks with robust performance in instruction adherence and logical reasoning.                                                                                                                                                                                                                 |
-| English    | Qwen2-0.5B-Instruct-GGUF                            | [Link](https://huggingface.co/Qwen/Qwen2-0.5B-Instruct-GGUF)                                     | A 0.5B parameter instruction-tuned model from the Qwen2 series, excelling in language understanding, generation, and multilingual tasks with competitive performance against state-of-the-art models.                                                                                                                                                                                                   |
-| English    | GritLM_-_GritLM-7B-gguf                             | [Link](https://huggingface.co/RichardErkhov/GritLM_-_GritLM-7B-gguf)                             | A unified model for both text generation and embedding tasks, achieving state-of-the-art performance in both areas and enhancing Retrieval-Augmented Generation (RAG) efficiency by over 60%.                                                                                                                                                                                                           |
-| English    | falcon-7b-instruct-GGUF                             | [Link](https://huggingface.co/QuantFactory/falcon-7b-instruct-GGUF)                              | A 7B parameter instruct model based on Falcon-7B, optimized for chat and instruction tasks with performance benefits from extensive training on 1,500B tokens, and optimized inference architecture.                                                                                                                                                                                                    |
-| English    | Samantha-Qwen-2-7B-GGUF                             | [Link](https://huggingface.co/QuantFactory/Samantha-Qwen-2-7B-GGUF)                              | A quantized 7B parameter model fine-tuned with QLoRa and FSDP, tailored for conversational tasks and utilizing datasets like OpenHermes-2.5 and Opus_Samantha.                                                                                                                                                                                                                                          |
-| English    | Mistral-7B-Instruct-v0.3-GGUF                       | [Link](https://huggingface.co/MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF)                       | An instruct fine-tuned model based on Mistral-7B-v0.3, featuring an extended vocabulary and support for function calling, aimed at demonstrating effective fine-tuning with room for improved moderation mechanisms.                                                                                                                                                                                    |
-| English    | Lite-Mistral-150M-v2-Instruct-GGUF                  | [Link](https://huggingface.co/OuteAI/Lite-Mistral-150M-v2-Instruct-GGUF)                         | A compact 150M parameter model optimized for efficiency on various devices, demonstrating reasonable performance in simple queries but facing challenges with context preservation and accuracy in multi-turn conversations.                                                                                                                                                                            |
-| English    | TowerInstruct-7B-v0.1-GGUF                          | [Link](https://huggingface.co/TheBloke/TowerInstruct-7B-v0.1-GGUF)                               | A 7B parameter model fine-tuned on the TowerBlocks dataset for translation tasks, including general, context-aware, and terminology-aware translation, as well as named-entity recognition and grammatical error correction.                                                                                                                                                                            |
-| English    | Dr_Samantha-7B-GGUF                                 | [Link](https://huggingface.co/TheBloke/Dr_Samantha-7B-GGUF)                                      | A merged model incorporating medical and psychological knowledge, with extensive performance on medical knowledge tasks and a focus on whole-person care.                                                                                                                                                                                                                                               |
-| English    | phi-2-orange-GGUF                                   | [Link](https://huggingface.co/rhysjones/phi-2-orange)                                            | A finetuned model based on Phi-2, optimized with a two-step finetuning approach for improved performance in various evaluation metrics. The model is designed for Python-related tasks and general question answering.                                                                                                                                                                                  |
-| English    | phi-2-electrical-engineering-GGUF                   | [Link](https://huggingface.co/TheBloke/phi-2-electrical-engineering-GGUF)                        | The phi-2-electrical-engineering model excels in answering questions and generating code specifically for electrical engineering and Kicad software, boasting efficient deployment and a focus on technical accuracy within its 2.7 billion parameters.                                                                                                                                                 |
-| English    | Unholy-v2-13B-GGUF                                  | [Link](https://huggingface.co/TheBloke/Unholy-v2-13B-GGUF)                                       | An uncensored 13B parameter model merged with various models for an uncensored experience, designed to bypass typical content moderation filters.                                                                                                                                                                                                                                                       |
-| English    | CapybaraHermes-2.5-Mistral-7B-GGUF                  | [Link](https://huggingface.co/TheBloke/CapybaraHermes-2.5-Mistral-7B-GGUF)                       | A preference-tuned 7B model using distilabel, optimized for multi-turn performance with improved scores in benchmarks like MTBench and Nous, compared to the Mistral-7B-Instruct-v0.2.                                                                                                                                                                                                                  |
-| English    | notus-7B-v1-GGUF                                    | [Link](https://huggingface.co/TheBloke/notus-7B-v1-GGUF)                                         | A 7B parameter model fine-tuned with Direct Preference Optimization (DPO), surpassing Zephyr-7B-beta and Claude 2 on AlpacaEval, designed for chat-like applications with improved preference-based performance.                                                                                                                                                                                        |
-| English    | Luna AI Llama2 Uncensored GGML                      | [Link](https://huggingface.co/TheBloke/Luna-AI-Llama2-Uncensored-GGML)                           | A Llama2-based chat model fine-tuned on over 40,000 long-form chat discussions. Optimized with synthetic outputs, available in both 4-bit GPTQ for GPU and GGML for CPU inference. Prompt format follows Vicuna 1.1/OpenChat style.                                                                                                                                                                     |
-| English    | Zephyr-7B-β-GGUF                                    | [Link](https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF)                                      | A 7B parameter model fine-tuned with Direct Preference Optimization (DPO) to enhance performance, optimized for helpfulness but may generate problematic text due to removed in-built alignment.                                                                                                                                                                                                        |
-| English    | TinyLlama-1.1B-1T-OpenOrca-GGUF                     | [Link](https://huggingface.co/TheBloke/TinyLlama-1.1B-1T-OpenOrca-GGUF)                          | A 1.1B parameter model fine-tuned on the OpenOrca GPT-4 subset, optimized for conversational tasks with a focus on efficiency and performance in the CHATML format.                                                                                                                                                                                                                                     |
-| English    | LlongOrca-7B-16K-GGUF                               | [Link](https://huggingface.co/TheBloke/LlongOrca-7B-16K-GGUF)                                    | A fine-tuned 7B parameter model optimized for long contexts, achieving top performance in long-context benchmarks and notable improvements over the base model, with efficient training using OpenChat's MultiPack algorithm.                                                                                                                                                                           |
-| English    | Meta-Llama-3-8B-Instruct-GGUF                       | [Link](https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF)                        | An 8B parameter instruction-tuned model from the Llama 3 series, optimized for dialogue and outperforming many open-source models on industry benchmarks, with a focus on helpfulness and safety through advanced fine-tuning techniques.                                                                                                                                                               |
-| English    | Smol-7B-GGUF                                        | [Link](https://huggingface.co/TheBloke/smol-7B-GGUF)                                             | A fine-tuned 7B parameter model from the Smol series, known for its strong performance in diverse NLP tasks and efficient fine-tuning techniques.                                                                                                                                                                                                                                                       |
-| English    | Smol-Llama-101M-Chat-v1-GGUF                        | [Link](https://huggingface.co/afrideva/Smol-Llama-101M-Chat-v1-GGUF)                             | A compact 101M parameter chat model optimized for diverse conversational tasks, showing balanced performance across multiple benchmarks with a focus on efficiency and low-resource scenarios.                                                                                                                                                                                                          |
-| English    | Sonya-7B-GGUF                                       | [Link](https://huggingface.co/TheBloke/Sonya-7B-GGUF)                                            | A high-performing 7B model with excellent scores in MT-Bench, ideal for various tasks including assistant and roleplay, combining multiple sources to achieve superior performance.                                                                                                                                                                                                                     |
-| English    | WizardLM-7B-uncensored-GGML                         | [Link](https://huggingface.co/TheBloke/WizardLM-7B-uncensored-GGML)                              | An uncensored 7B parameter model from the WizardLM series, designed without built-in alignment to allow for custom alignment via techniques like RLHF LoRA, with no guardrails and complete responsibility for content usage resting on the user.                                                                                                                                                       |
-| English    | OpenChat 3.5                                        | [Link](https://huggingface.co/TheBloke/openchat_3.5-GGUF)                                        | A 7B parameter model that achieves comparable results with ChatGPT, excelling in MT-bench evaluations. It utilizes mixed-quality data and C-RLFT (a variant of offline reinforcement learning) for training. OpenChat 3.5 performs well across various benchmarks and has been optimized for high-throughput deployment. It is an open-source model with strong performance in chat-based applications. |
-| Portuguese | PORTULAN_-_gervasio-7b-portuguese-ptpt-decoder-gguf | [Link](https://huggingface.co/RichardErkhov/PORTULAN_-_gervasio-7b-portuguese-ptpt-decoder-gguf) | Gervásio 7B PTPT is an open decoder for Portuguese, built on the LLaMA-2 7B model, fine-tuned with instruction data to excel in various Portuguese tasks, and designed to run on consumer-grade hardware with a focus on European Portuguese.                                                                                                                                                           |
-| Portuguese | CabraLlama3-8b-GGUF                                 | [Link](https://huggingface.co/mradermacher/CabraLlama3-8b-GGUF)                                  | A refined version of Meta-Llama-3-8B-Instruct, optimized with the Cabra 30k dataset for understanding and responding in Portuguese, providing enhanced performance for Portuguese language tasks.                                                                                                                                                                                                       |
-| Portuguese | bode-7b-alpaca-pt-br-gguf                           | [Link](https://huggingface.co/recogna-nlp/bode-7b-alpaca-pt-br-gguf)                             | Bode-7B is a fine-tuned LLaMA 2-based model designed for Portuguese, delivering satisfactory results in classification tasks and prompt-based applications.                                                                                                                                                                                                                                             |
-| Portuguese | bode-13b-alpaca-pt-br-gguf                          | [Link](https://huggingface.co/recogna-nlp/bode-13b-alpaca-pt-br-gguf)                            | Bode-13B is a fine-tuned LLaMA 2-based model for Portuguese prompts, offering enhanced performance over its 7B counterpart, and designed for both research and commercial applications with a focus on Portuguese language tasks.                                                                                                                                                                       |
-| Portuguese | sabia-7B-GGUF                                       | [Link](https://huggingface.co/TheBloke/sabia-7B-GGUF)                                            | Sabiá-7B is a Portuguese auto-regressive language model based on LLaMA-1-7B, pretrained on a large Portuguese dataset, offering high performance in few-shot tasks and generating text, with research-only licensing.                                                                                                                                                                                   |
-| Portuguese | OpenHermesV2-PTBR-portuguese-brazil-gguf            | [Link](https://huggingface.co/skoll520/OpenHermesV2-PTBR-portuguese-brazil-gguf)                 | A finetuned version of Mistral 7B trained on diverse GPT-4 generated data, designed for Portuguese, with extensive filtering and transformation for enhanced performance.                                                                                                                                                                                                                               |
-| Catalan    | CataLlama-v0.2-Instruct-SFT-DPO-Merged-GGUF         | [Link](https://huggingface.co/catallama/CataLlama-v0.2-Instruct-SFT-DPO-Merged-GGUF)             | An instruction-tuned model optimized with DPO for various NLP tasks in Catalan, including translation, NER, summarization, and sentiment analysis, built on an auto-regressive transformer architecture.                                                                                                                                                                                                |
-
-> The models listed are suggestions. The best model for your use case will depend on your specific requirements such as
-> language, task complexity, and performance needs.
-
-
-
-
-## Text Embeddings
-
-`GGUFEmbeddings` turns text into dense vectors for semantic search, clustering and retrieval. It pairs with any OVOS
-`EmbeddingsDB` vector store (e.g. `ovos-chromadb-embeddings-plugin`, `ovos-qdrant-embeddings-plugin`).
-
-`model` accepts a friendly name from `GGUFEmbeddings.DEFAULT_MODELS` (e.g. `labse`, `all-MiniLM-L6-v2`,
-`nomic-embed-text-v1.5`, `bge-large-en-v1.5`), a bare Hugging Face repo id (with `remote_filename`), or a local
-`.gguf` path. Default is `labse`.
+### Text embeddings
 
 ```python
 from ovos_gguf_plugin.embeddings import GGUFEmbeddings
 
-embedder = GGUFEmbeddings({"model": "all-MiniLM-L6-v2"})
-vector = embedder.get_embeddings("hello world")
+emb = GGUFEmbeddings({"model": "all-MiniLM-L6-v2"})
+vector = emb.get_embeddings("hello world")
+print(len(vector), "dims")
 ```
 
-As an OVOS text-embeddings plugin it is selected by name (`ovos-gguf-embeddings-plugin`), so it is a drop-in for
-anything that previously used the standalone embeddings plugin — install `ovos-gguf-plugin` and the name resolves.
+`model` accepts a friendly name from `GGUFEmbeddings.DEFAULT_MODELS` (e.g. `labse`, `all-MiniLM-L6-v2`, `nomic-embed-text-v1.5`, `bge-large-en-v1.5`), a bare Hugging Face repo id (with `remote_filename`), or a local `.gguf` path. Default is `labse`.
+
+As an OVOS text-embeddings plugin it is selected by name (`ovos-gguf-embeddings-plugin`), so it is a drop-in for anything that previously used the standalone embeddings plugin.
+
+## Configuration
+
+All wrappers share the same config keys:
+
+| Key | Default | Description |
+|---|---|---|
+| `model` | required | Local `.gguf` path, HuggingFace repo id, or friendly name (embeddings) |
+| `remote_filename` | `*Q4_K_M.gguf` | Glob for selecting the file from a HF repo |
+| `n_gpu_layers` | `0` | GPU layers to offload (`-1` = all) |
+| `chat_format` | `None` | llama.cpp chat format (auto-detected for most models) |
+| `verbose` | `True` | llama.cpp verbosity |
+| `max_tokens` | `512` | Maximum tokens to generate |
+| `system_prompt` | locale default | Override the system prompt |
+
+See [`docs/configuration.md`](docs/configuration.md) for the full reference including per-wrapper options and GPU build instructions.
+
+## Localized prompts
+
+System prompts and templates ship as `.prompt` resource files under `ovos_gguf_plugin/locale/<lang>/` and are loaded via [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools) (OVOS-INTENT-2 §4.4). Drop translated `.prompt` files under a new `locale/<lang>/` to add a language; English `en-us` ships by default and is the fallback. A `system_prompt` in config overrides the locale file.
+
+See [`docs/localization.md`](docs/localization.md) for the full guide.
+
+## OVOS Persona Framework
+
+```json
+{
+  "name": "MyAssistant",
+  "solvers": ["ovos-solver-gguf-plugin"],
+  "ovos-solver-gguf-plugin": {
+    "model": "TheBloke/notus-7B-v1-GGUF",
+    "remote_filename": "*Q4_K_M.gguf",
+    "persona": "You are a helpful assistant.",
+    "verbose": false
+  }
+}
+```
+
+```bash
+ovos-persona-server --persona my_persona.json
+```
+
+## Documentation
+
+- [`docs/configuration.md`](docs/configuration.md) — full config reference, GPU build, per-wrapper notes
+- [`docs/localization.md`](docs/localization.md) — `.prompt` system, adding a language
+- [`docs/models.md`](docs/models.md) — recommended models per wrapper (including tiny CI-friendly ones)
+
+## Examples
+
+Runnable scripts under [`examples/`](examples/):
+
+- [`chat_example.py`](examples/chat_example.py)
+- [`embeddings_example.py`](examples/embeddings_example.py)
+- [`translate_example.py`](examples/translate_example.py)
+- [`lang_detect_example.py`](examples/lang_detect_example.py)
+- [`summarize_example.py`](examples/summarize_example.py)
+
+## Testing
+
+```bash
+pip install "ovos-gguf-plugin[test]"
+python -m pytest test/ -v
+```
+
+The test suite contains:
+
+- `test/test_embeddings.py` — hermetic unit tests (mocked llama.cpp, no downloads)
+- `test/test_prompts.py` — hermetic unit tests for localized prompt loading
+- `test/test_e2e.py` — real-model end-to-end tests (downloads tiny GGUFs once, ~70 MB total):
+  - chat: `afrideva/Smol-Llama-101M-Chat-v1-GGUF` q2_k (~45 MB)
+  - embeddings: `leliuga/all-MiniLM-L6-v2-GGUF` Q4_K_M (~23 MB)
 
 ## Credits
 
 Originally developed by [TigreGótico](https://tigregotico.pt) for [OpenVoiceOS](https://openvoiceos.org),
 sponsored by VisioLab. Modernized under the [NGI0 Commons Fund](https://nlnet.nl/commonsfund) / [NLnet](https://nlnet.nl).
 
-![image](https://github.com/user-attachments/assets/809588a2-32a2-406c-98c0-f88bf7753cb4)
+<img src="https://github.com/user-attachments/assets/809588a2-32a2-406c-98c0-f88bf7753cb4" width="220" alt="VisioLab"/>
 
 > This work was sponsored by VisioLab, part of [Royal Dutch Visio](https://visio.org/), is the test, education, and research center in the field of (innovative) assistive technology for blind and visually impaired people and professionals. We explore (new) technological developments such as Voice, VR and AI and make the knowledge and expertise we gain available to everyone.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,92 @@
+# Recommended Models
+
+Models are loaded from the Hugging Face Hub by default. The `model` key accepts a hub repo id; `remote_filename` is a glob that selects the quantization variant. Local `.gguf` paths work too.
+
+## Chat / Summarizer / Dialog / Lang-detect / Translate
+
+These wrappers use generative chat models. Any instruction-tuned GGUF model works; smaller ones run faster on CPU.
+
+### Tiny (CI / low-RAM, < 200 MB)
+
+| Model | `model` | `remote_filename` | Notes |
+|---|---|---|---|
+| Smol-Llama 101M | `afrideva/Smol-Llama-101M-Chat-v1-GGUF` | `*q2_k.gguf` | ~45 MB; used in CI e2e tests |
+| Lite-Mistral 150M | `OuteAI/Lite-Mistral-150M-v2-Instruct-GGUF` | `*Q4_K_M.gguf` | ~100 MB |
+
+### Small (1–2 GB, good for Raspberry Pi 5)
+
+| Model | `model` | `remote_filename` | Notes |
+|---|---|---|---|
+| Qwen2 0.5B Instruct | `Qwen/Qwen2-0.5B-Instruct-GGUF` | `*q8_0.gguf` | multilingual |
+| TinyLlama 1.1B | `TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF` | `*Q4_K_M.gguf` | English |
+
+### Medium (4–8 GB)
+
+| Model | `model` | `remote_filename` | Notes |
+|---|---|---|---|
+| Mistral 7B Instruct v0.3 | `MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF` | `*Q4_K_M.gguf` | strong general |
+| Phi-3 Mini 4K | `microsoft/Phi-3-mini-4k-instruct-gguf` | `*Q4_K_M.gguf` | 3.8B, very capable |
+| Qwen2 7B Instruct | `Qwen/Qwen2-7B-Instruct-GGUF` | `*Q4_K_M.gguf` | multilingual |
+
+### Translation-specific
+
+| Model | `model` | `remote_filename` | Notes |
+|---|---|---|---|
+| TowerInstruct 7B | `TheBloke/TowerInstruct-7B-v0.1-GGUF` | `*Q4_K_M.gguf` | fine-tuned for translation |
+
+### Portuguese
+
+| Model | `model` | `remote_filename` |
+|---|---|---|
+| Gervásio 7B PTPT | `RichardErkhov/PORTULAN_-_gervasio-7b-portuguese-ptpt-decoder-gguf` | `*Q4_K_M.gguf` |
+| CabraLlama3 8B | `mradermacher/CabraLlama3-8b-GGUF` | `*Q4_K_M.gguf` |
+| Bode 7B PT-BR | `recogna-nlp/bode-7b-alpaca-pt-br-gguf` | `*Q4_K_M.gguf` |
+
+### Catalan
+
+| Model | `model` | `remote_filename` |
+|---|---|---|
+| CataLlama v0.2 | `catallama/CataLlama-v0.2-Instruct-SFT-DPO-Merged-GGUF` | `*Q4_K_M.gguf` |
+
+---
+
+## Embeddings
+
+`GGUFEmbeddings` supports friendly names from `GGUFEmbeddings.DEFAULT_MODELS`:
+
+### Tiny (< 30 MB)
+
+| Friendly name | Repo | Dims | Notes |
+|---|---|---|---|
+| `all-MiniLM-L6-v2` | `leliuga/all-MiniLM-L6-v2-GGUF` | 384 | used in CI e2e tests |
+| `e5-small-v2` | `ChristianAzinn/e5-small-v2-gguf` | 384 | |
+| `gte-small` | `ChristianAzinn/gte-small-gguf` | 384 | |
+
+### Small (30–100 MB)
+
+| Friendly name | Repo | Dims | Notes |
+|---|---|---|---|
+| `all-MiniLM-L12-v2` | `leliuga/all-MiniLM-L12-v2-GGUF` | 384 | |
+| `bge-small-en-v1.5` | `ChristianAzinn/bge-small-en-v1.5-gguf` | 384 | English |
+| `gte-base` | `ChristianAzinn/gte-base-gguf` | 768 | |
+| `snowflake-arctic-embed-xs` | `ChristianAzinn/snowflake-arctic-embed-xs-gguf` | 384 | |
+| `snowflake-arctic-embed-s` | `ChristianAzinn/snowflake-arctic-embed-s-gguf` | 384 | |
+
+### Multilingual
+
+| Friendly name | Repo | Dims | Notes |
+|---|---|---|---|
+| `labse` | `ChristianAzinn/labse-gguf` | 768 | 109 languages, default |
+| `nomic-embed-text-v1.5` | `nomic-ai/nomic-embed-text-v1.5-GGUF` | 768 | |
+
+### Large / high-quality
+
+| Friendly name | Repo | Dims | Notes |
+|---|---|---|---|
+| `bge-large-en-v1.5` | `ChristianAzinn/bge-large-en-v1.5-gguf` | 1024 | English |
+| `mxbai-embed-large-v1` | `ChristianAzinn/mxbai-embed-large-v1-gguf` | 1024 | |
+| `uae-large-v1` | `ChristianAzinn/uae-large-v1-gguf` | 1024 | |
+| `gte-large` | `ChristianAzinn/gte-large-gguf` | 1024 | |
+| `gte-Qwen2-1.5B-instruct` | `second-state/gte-Qwen2-1.5B-instruct-GGUF` | 1536 | multilingual |
+
+> These are community-maintained GGUF quantizations. Check the linked repos for licensing details before use in production.

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -1,0 +1,80 @@
+"""Real-model end-to-end tests.
+
+These tests download tiny GGUF models and run actual inference.  They are
+included in the standard ``test/`` path so CI picks them up via the
+``build_tests.yml`` workflow (``test_path: "test"``).  First run downloads
+models to the HuggingFace cache; subsequent runs are fast.
+
+Chat model  : afrideva/Smol-Llama-101M-Chat-v1-GGUF  (~45 MB q2_k)
+Embed model : leliuga/all-MiniLM-L6-v2-GGUF           (~23 MB Q4_K_M)
+"""
+import time
+
+import numpy as np
+import pytest
+
+from ovos_gguf_plugin.chat import GGUFChatEngine
+from ovos_gguf_plugin.embeddings import GGUFEmbeddings
+from ovos_plugin_manager.templates.agents import AgentMessage, MessageRole
+
+
+# ---------------------------------------------------------------------------
+# Chat engine
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def chat_engine():
+    return GGUFChatEngine({
+        "model": "afrideva/Smol-Llama-101M-Chat-v1-GGUF",
+        "remote_filename": "*q2_k.gguf",
+        "max_tokens": 24,
+        "verbose": False,
+    })
+
+
+def test_chat_continue_returns_nonempty_string(chat_engine):
+    msgs = [AgentMessage(role=MessageRole.USER, content="Say hello.")]
+    t0 = time.time()
+    resp = chat_engine.continue_chat(msgs)
+    elapsed = time.time() - t0
+    assert isinstance(resp.content, str)
+    assert len(resp.content.strip()) > 0
+    assert resp.role == MessageRole.ASSISTANT
+    # sanity: tiny model + 24 tokens should finish well under 30 s
+    assert elapsed < 30, f"inference took {elapsed:.1f}s"
+
+
+def test_chat_stream_sentences_yields_at_least_one_chunk(chat_engine):
+    msgs = [AgentMessage(role=MessageRole.USER, content="Say hello.")]
+    chunks = list(chat_engine.stream_sentences(msgs))
+    assert len(chunks) >= 1
+    assert all(isinstance(c, str) and c for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def embedder():
+    return GGUFEmbeddings({"model": "all-MiniLM-L6-v2"})
+
+
+def test_embeddings_returns_numpy_vector(embedder):
+    vec = embedder.get_embeddings("hello")
+    assert isinstance(vec, np.ndarray)
+    assert vec.ndim == 1
+    assert len(vec) > 0
+
+
+def test_embeddings_vector_length_is_384(embedder):
+    # all-MiniLM-L6-v2 produces 384-dim vectors
+    vec = embedder.get_embeddings("the quick brown fox")
+    assert len(vec) == 384
+
+
+def test_embeddings_different_texts_differ(embedder):
+    v1 = embedder.get_embeddings("cat")
+    v2 = embedder.get_embeddings("quantum physics")
+    # cosine distance should be non-trivial
+    assert not np.allclose(v1, v2)


### PR DESCRIPTION
Re-homed onto current `dev` (the prior productionization commit was stranded when #15 squash-merged mid-flight).

- New production **README.md** + `docs/models.md`.
- **Real-model e2e** `test/test_e2e.py`: Smol-Llama-101M-Chat Q2_K (52 MB) chat + all-MiniLM-L6-v2 (384-dim) embeddings — actually runs inference in CI. **20 tests pass** locally.
- Constrained the oversized VisioLab sponsor logo to `width=220`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)