### PR TITLE
test: full-pipeline persona e2e (real GGUF through ovoscope)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ test = [
     "numpy",
     "ovoscope",
     "ovos-persona",
-    "ovos-persona-pipeline-plugin",
     "ovos-solver-failure-plugin",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "numpy"]
+test = [
+    "pytest",
+    "numpy",
+    "ovoscope",
+    "ovos-persona",
+    "ovos-persona-pipeline-plugin",
+    "ovos-solver-failure-plugin",
+]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-gguf-plugin"

--- a/test/test_e2e_persona_pipeline.py
+++ b/test/test_e2e_persona_pipeline.py
@@ -1,0 +1,168 @@
+"""Capstone end-to-end test: GGUF-backed persona through the full OVOS pipeline.
+
+Proves:
+  1. An utterance flows through the real OVOS intent pipeline, hits the persona
+     pipeline plugin (which delegates to a GGUFChatEngine handler), and produces
+     a ``speak`` message with non-empty text.
+  2. Per-session memory is recorded: the live PersonaService accumulates USER +
+     ASSISTANT turns keyed by session_id after the pipeline runs.
+
+A tiny real GGUF model is downloaded once (~52 MB) on first run and cached in
+the HuggingFace cache.  No other network access is required.
+
+Model: afrideva/Smol-Llama-101M-Chat-v1-GGUF (*q2_k.gguf, ~52 MB)
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+ovoscope = pytest.importorskip("ovoscope")
+pytest.importorskip("ovos_persona")
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+
+from ovoscope import (
+    PERSONA_PIPELINE,
+    CaptureSession,
+    get_minicroft,
+    is_pipeline_available,
+)
+
+if not is_pipeline_available(PERSONA_PIPELINE):
+    pytest.skip("ovos-persona-pipeline-plugin not installed", allow_module_level=True)
+
+# ---------------------------------------------------------------------------
+# Persona dir + config
+# ---------------------------------------------------------------------------
+
+PERSONA_NAME = "TinyBot"
+_TMPDIR = tempfile.mkdtemp()
+
+_PERSONA = {
+    "name": PERSONA_NAME,
+    "handlers": ["ovos-chat-gguf-plugin"],
+    "ovos-chat-gguf-plugin": {
+        "model": "afrideva/Smol-Llama-101M-Chat-v1-GGUF",
+        "remote_filename": "*q2_k.gguf",
+        "max_tokens": 24,
+        "verbose": False,
+    },
+}
+
+with open(os.path.join(_TMPDIR, f"{PERSONA_NAME}.json"), "w") as _fh:
+    json.dump(_PERSONA, _fh)
+
+PIPELINE_CONFIG = {
+    "persona": {
+        "personas_path": _TMPDIR,
+        "default_persona": PERSONA_NAME,
+        "short-term-memory": True,
+        "handle_fallback": True,
+        "ignore_plugin_personas": True,
+    }
+}
+
+TEST_PIPELINE = [
+    "ovos-persona-pipeline-plugin-high",
+    "ovos-persona-pipeline-plugin-low",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module-level MiniCroft (shared for speed — model loads once)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def mc():
+    croft = get_minicroft(
+        skill_ids=[],
+        default_pipeline=TEST_PIPELINE,
+        pipeline_config=PIPELINE_CONFIG,
+    )
+    yield croft
+    croft.stop()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utterance_msg(utterance: str, sess: Session) -> Message:
+    return Message(
+        "recognizer_loop:utterance",
+        {"utterances": [utterance], "lang": sess.lang},
+        {"session": sess.serialize()},
+    )
+
+
+def _drive(croft, sess: Session, utterance: str, timeout: int = 90):
+    cap = CaptureSession(
+        croft,
+        eof_msgs=["ovos.utterance.handled", "ovos.utterance.cancelled"],
+    )
+    cap.capture(_utterance_msg(utterance, sess), timeout=timeout)
+    return cap.finish()
+
+
+def _persona_service(croft):
+    return croft.intents.pipeline_plugins["ovos-persona-pipeline-plugin"]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: GGUF persona speaks through the full pipeline
+# ---------------------------------------------------------------------------
+
+class TestGGUFPersonaSpeaksThroughPipeline:
+    """Utterance must traverse the full OVOS intent pipeline and produce a
+    ``speak`` message whose ``utterance`` field is non-empty (i.e. a real
+    GGUF model generated a response and it was routed through the pipeline)."""
+
+    def test_pipeline_produces_speak(self, mc):
+        sess = Session(session_id="gguf-e2e-speak")
+        SessionManager.sessions[sess.session_id] = sess
+
+        messages = _drive(mc, sess, "hello, who are you?", timeout=90)
+
+        msg_types = [m.msg_type for m in messages]
+        speak_msgs = [m for m in messages if m.msg_type == "speak"]
+
+        assert speak_msgs, (
+            f"Expected at least one 'speak' message; got msg_types: {msg_types}"
+        )
+        spoken = speak_msgs[0].data.get("utterance", "")
+        assert spoken.strip(), (
+            f"'speak' message had empty utterance; data={speak_msgs[0].data}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: per-session memory recorded after pipeline run
+# ---------------------------------------------------------------------------
+
+class TestGGUFPersonaMemoryRecorded:
+    """After a pipeline turn the PersonaService must have recorded the
+    USER input (and an ASSISTANT response) in the persona's short-term memory,
+    keyed by session_id."""
+
+    def test_memory_contains_turn(self, mc):
+        svc = _persona_service(mc)
+        sess = Session(session_id="gguf-e2e-mem")
+        SessionManager.sessions[sess.session_id] = sess
+
+        persona = svc.personas.get(PERSONA_NAME)
+        assert persona is not None, f"Persona '{PERSONA_NAME}' not loaded"
+        assert persona.memory is not None, "Persona must have short-term memory enabled"
+
+        _drive(mc, sess, "hello, who are you?", timeout=90)
+
+        history = persona.memory.get_history(sess.session_id)
+        assert history, (
+            f"Memory empty after pipeline turn for session {sess.session_id}"
+        )
+        contents = [m.content for m in history]
+        assert any("hello" in c.lower() for c in contents), (
+            f"User utterance not found in memory. History: {contents}"
+        )


### PR DESCRIPTION
Drives a `TinyBot` persona backed by `ovos-chat-gguf-plugin` (Smol-Llama-101M Q2_K, ~52 MB) through a real MiniCroft OVOS pipeline via ovoscope: asserts the persona **speaks** (captured `speak`) and that the turn is recorded in the live `PersonaService`'s per-session memory. Real model, no keys/network. 22 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing for persona pipeline functionality, including validation of persona speech output and memory recording capabilities.
  * Expanded test dependencies to improve test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->